### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :edit_access_check, only: [:edit, :update]
-  before_action :set_item, only: [:show, :edit]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -27,7 +27,6 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :edit_access_check, only: [:edit]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -22,10 +23,34 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:name, :price, :text, :category_id, :status_id, :prefectures_id, :delivery_fee_id,
                                  :shipping_id, :image).merge(user_id: current_user.id)
   end
+
+  def edit_access_check
+    item = Item.find(params[:id])
+    if user_signed_in? && current_user.id != item.user_id
+       redirect_to root_path
+    elsif user_signed_in? 
+    else
+       redirect_to new_user_session_path
+    end
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,11 +46,10 @@ class ItemsController < ApplicationController
   def edit_access_check
     item = Item.find(params[:id])
     if user_signed_in? && current_user.id != item.user_id
-       redirect_to root_path
-    elsif user_signed_in? 
+      redirect_to root_path
+    elsif user_signed_in?
     else
-       redirect_to new_user_session_path
+      redirect_to new_user_session_path
     end
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :edit_access_check, only: [:edit]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :edit_access_check, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -20,11 +21,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
@@ -43,13 +42,15 @@ class ItemsController < ApplicationController
                                  :shipping_id, :image).merge(user_id: current_user.id)
   end
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+
   def edit_access_check
     item = Item.find(params[:id])
-    if user_signed_in? && current_user.id != item.user_id
+    if current_user.id != item.user_id
       redirect_to root_path
-    elsif user_signed_in?
-    else
-      redirect_to new_user_session_path
     end
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,13 +1,15 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model:@item, local: true do |f| %>
 
-    <% render 'devise/shared/error_messages', model: f.object %>
+    <%= render 'devise/shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -109,8 +111,8 @@
           <span>販売利益</span>
           <span>
             <span id='profit'></span>円
+          </span>
         </div>
-        </span>
       </div>
     </div>
     <%# /販売価格 %>
@@ -136,8 +138,8 @@
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,13 +132,13 @@
           <div class='item-img-content'>
            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <%# <div class='sold-out'>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
+          </div>
           <div class='item-info'>
            <h3 class='item-name'>
              <%= item.name %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -7,7 +7,7 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model:@item, local: true do |f| %>
 
-    <% render 'devise/shared/error_messages', model: f.object %>
+    <%= render 'devise/shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && @item.user_id == current_user.id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root "items#index"
-  resources :items, only: [:new, :create, :show]
+  resources :items, only: [:new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の実装

# Way
ユーザーが出品した商品の情報を編集可能にする為。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/8fc155cc669a873d9e9f80e5cc4442c7

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/586cfc37d95cf5752964ba7aad00c084

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/68ab359ca27441db05b7906e92392e3a

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/6d60f800cec0dd1cd532cae7d92b6963

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/3c72b06048309abf0caf4334bcb9fc2e

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/c44416633efd1c2bb0b0e832e4dacae1
